### PR TITLE
make file name unique regardless of file name even the files has same name

### DIFF
--- a/api/v3/CiviOutlook.php
+++ b/api/v3/CiviOutlook.php
@@ -434,9 +434,8 @@ function civicrm_api3_civi_outlook_processattachments($params) {
         CRM_Core_Error::debug_log_message($error);
       }
 
-
-      $explodeName = explode(".".$fileExtension->getExtension(), $name);
-      $name = $explodeName[0]."_".md5($name).".".$fileExtension->getExtension();
+      // calling civi method to make attached file name. This makes unique name regardless of same file name
+      $name = CRM_Utils_File::makeFileName($_FILES['file']['name']);
     }
 
     $_FILES['file']['uri'] = $name;


### PR DESCRIPTION
- If we have attachment with same name it causes previous activity attachement replaced with latest attachement

- This pr solves the issue