### PR TITLE
Bugfix: Users without administer CiviCRM are unable to view CiviCases

### DIFF
--- a/outlookapi.php
+++ b/outlookapi.php
@@ -118,7 +118,7 @@ function outlookapi_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 function outlookapi_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
   //Native APIs
   $permissions['domain'] = array('get' => array('access CiviCRM', 'access AJAX API'));
-  $permissions['activity'] = array('create' => array('access CiviCRM', 'access AJAX API', 'add contacts', 'view all contacts', 'view all activities', 'access uploaded files'));
+  array_merge($permissions['activity'], array('create' => array('access CiviCRM', 'access AJAX API', 'add contacts', 'view all contacts', 'view all activities', 'access uploaded files')));
 
   //Custom APIs
   $permissions['civi_outlook']['getdomain'] = array('access CiviCRM','access AJAX API');


### PR DESCRIPTION
This fixes a reproducible bug whilst using the Outlook API Extension (disabling this extension fixes the issue). The client had users who were unable to view cases and were presented with the error:
> CiviCRM_API3_Exception: "API permission check failed for Activity/getcount call; insufficient permission: require administer CiviCRM"

When it stated the permission didn't have "administer CiviCRM", it was either going to be a Core bug or an extension interfering with it. Quick search lead to this extension overriding permissions (see changes for the fix).
### Expected Outcome
Be able to view cases whilst the Outlook API extension is enabled.
### Actual Outcome
Presented with the above error, and following traceback:
```TXT
#0 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Activity/BAO/Activity.php(950): civicrm_api3("Activity", "getcount", (Array:11))
#1 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Activity/Selector/Activity.php(361): CRM_Activity_BAO_Activity::getActivitiesCount((Array:8))
#2 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Core/Selector/Controller.php(234): CRM_Activity_Selector_Activity->getTotalCount(4, "316")
#3 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Case/Page/Tab.php(122): CRM_Core_Selector_Controller->__construct(Object(CRM_Activity_Selector_Activity), NULL, NULL, 4, Object(CRM_Case_Page_Tab), 1, NULL, "316")
#4 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Case/Page/Tab.php(196): CRM_Case_Page_Tab->view()
#5 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Core/Invoke.php(311): CRM_Case_Page_Tab->run((Array:4), NULL)
#6 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Core/Invoke.php(85): CRM_Core_Invoke::runItem((Array:13))
#7 /var/www/html/drupal7/sites/all/modules/civicrm/CRM/Core/Invoke.php(52): CRM_Core_Invoke::_invoke((Array:4))
#8 /var/www/html/drupal7/sites/all/modules/civicrm/drupal/civicrm.module(444): CRM_Core_Invoke::invoke((Array:4))
#9 /var/www/html/drupal7/includes/menu.inc(527): civicrm_invoke("contact", "view", "case")
#10 /var/www/html/drupal7/index.php(21): menu_execute_active_handler()
#11 {main}
```
URL:
* https://SITEURL/civicrm/contact/view/case?reset=1&id=316&cid=251&action=view&context=search&selectedChild=case&key=3df10cb548c7a1f8fd190e1a29e82693_9765

Environment:
*  Drupal 7.67
*  CiviCRM 5.13.0


Cheers